### PR TITLE
a sample test

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -64,5 +64,9 @@ TESTS = {
             "input": ['almaz', 'p', 'p'],
             "answer": False
         },
+        {
+            "input": ['almaz', 'r', 'a'],
+            "answer": False
+        },
     ]
 }


### PR DESCRIPTION
Once I tried the following ways to solve the problem, it passed the test, but someone pointed out that it was wrong
return word.find(first) == word.find(second) - 1 
e.g.  "input": ['almaz', 'r', 'a'],   'r' is not in 'almaz', so it should return False ,  word.find(first) is -1, and word.find(second)  is 0 , so word.find(second) - 1 equal word.find(first) , then it return True